### PR TITLE
Fix README.md typo: correct directory name from PolaRiS to polaris

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ PolaRiS is a evaluation framework for generalist policies. It provides tooling f
 
 ```bash
 git clone --recursive git@github.com:arhanjain/polaris.git
-cd PolaRiS
+cd polaris
 ```
 
 If you cloned without `--recursive`:


### PR DESCRIPTION
This PR fixes a typo in the README.md installation instructions.

## Changes made:
- Fixed directory name from PolaRiS to polaris in the cd command
- The git clone creates a directory named 'polaris' (lowercase) but the instructions showed 'PolaRiS'

This ensures the installation instructions work correctly for new users.

Fixes #17