### PR TITLE
docs: fix README clone directory command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ PolaRiS is a evaluation framework for generalist policies. It provides tooling f
 
 ```bash
 git clone --recursive git@github.com:arhanjain/polaris.git
-cd PolaRiS
+cd polaris
 ```
 
 If you cloned without `--recursive`:


### PR DESCRIPTION
Fixes #17

Update the install instructions to use `cd polaris`, matching the cloned directory name.