### PR TITLE
fix: correct 'occured' to 'occurred' typo in error messages

### DIFF
--- a/src/diff-surfel-rasterization/diff_surfel_rasterization/__init__.py
+++ b/src/diff-surfel-rasterization/diff_surfel_rasterization/__init__.py
@@ -220,7 +220,7 @@ class _RasterizeGaussians(torch.autograd.Function):
             except Exception as ex:
                 torch.save(cpu_args, "snapshot_fw.dump")
                 print(
-                    "\nAn error occured in forward. Please forward snapshot_fw.dump for debugging."
+                    "\nAn error occurred in forward. Please forward snapshot_fw.dump for debugging."
                 )
                 raise ex
         else:
@@ -310,7 +310,7 @@ class _RasterizeGaussians(torch.autograd.Function):
             except Exception as ex:
                 torch.save(cpu_args, "snapshot_bw.dump")
                 print(
-                    "\nAn error occured in backward. Writing snapshot_bw.dump for debugging.\n"
+                    "\nAn error occurred in backward. Writing snapshot_bw.dump for debugging.\n"
                 )
                 raise ex
         else:


### PR DESCRIPTION
## Summary
Corrected 'occured' to 'occurred' typo in two user-facing error messages in `src/diff-surfel-rasterization/diff_surfel_rasterization/__init__.py` (lines 223 and 313).

## Changes
- Line 223: `An error occured in forward` → `An error occurred in forward`
- Line 313: `An error occured in backward` → `An error occurred in backward`

These are print statements shown to users when rasterization errors occur during forward/backward passes.

## Compliance
- [x] Single commit
- [x] User-facing typo fix
- [x] 1 file changed (2 lines)